### PR TITLE
Docker: Fix entry point script

### DIFF
--- a/docker-start.sh
+++ b/docker-start.sh
@@ -7,5 +7,8 @@ PG_PORT=5432
 echo "Wait for postgres server to be ready..."
 while ! nc -q 1 $PG_HOST $PG_PORT </dev/null; do sleep 1; done
 
+# Create temporary directories
+mkdir -p tmp/pids
+
 bin/rails db:migrate
 bin/bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:3000


### PR DESCRIPTION
When deploying the current API to production, it failed to start:

    bundler: failed to load command: puma (/gems/bin/puma)
    Errno::ENOENT: No such file or directory @ rb_sysopen - tmp/pids/server.pid
      /gems/gems/puma-5.0.4/lib/puma/launcher.rb:233:in `initialize'
      /gems/gems/puma-5.0.4/lib/puma/launcher.rb:233:in `open'
      /gems/gems/puma-5.0.4/lib/puma/launcher.rb:233:in `write_pid'
      /gems/gems/puma-5.0.4/lib/puma/launcher.rb:102:in `write_state'
      /gems/gems/puma-5.0.4/lib/puma/cluster.rb:385:in `run'
      /gems/gems/puma-5.0.4/lib/puma/launcher.rb:171:in `run'
      /gems/gems/puma-5.0.4/lib/puma/cli.rb:80:in `run'
      /gems/gems/puma-5.0.4/bin/puma:10:in `<top (required)>'
      /gems/bin/puma:23:in `load'
      /gems/bin/puma:23:in `<top (required)>'

In `config/puma.rb`, the `PIDFILE` seems to default to
`tmp/pids/server.pid`, but the `tmp/pids/` directory does not exist.

Create that directory to ensure that the pidfile can be created.