### PR TITLE
Add latest_measurement_at to mobile sensor endpoints

### DIFF
--- a/app/controllers/mobile_app/sensors_controller.rb
+++ b/app/controllers/mobile_app/sensors_controller.rb
@@ -21,8 +21,7 @@ module MobileApp
                       .select('MAX(measurements.temperature) AS maximum_temperature')
                       .select('AVG(measurements.temperature) AS average_temperature')
                       .find(params[:id])
-      @latest_sensor_temperature = Measurement.where(sensor_id: params[:id]).order(created_at: :desc).first&.temperature
-      @latest_measurement_at = Measurement.where(sensor_id: params[:id]).order(created_at: :desc).first&.created_at
+      @latest_measurement = Measurement.where(sensor_id: params[:id]).order(created_at: :desc).first
     end
 
     def daily_temperatures

--- a/app/controllers/mobile_app/sensors_controller.rb
+++ b/app/controllers/mobile_app/sensors_controller.rb
@@ -22,7 +22,7 @@ module MobileApp
                       .select('AVG(measurements.temperature) AS average_temperature')
                       .find(params[:id])
       @latest_sensor_temperature = Measurement.where(sensor_id: params[:id]).order(created_at: :desc).first&.temperature
-      @latest_sensor_update = Measurement.where(sensor_id: params[:id]).order(created_at: :desc).first&.created_at
+      @latest_measurement_at = Measurement.where(sensor_id: params[:id]).order(created_at: :desc).first&.created_at
     end
 
     def daily_temperatures

--- a/app/controllers/mobile_app/sensors_controller.rb
+++ b/app/controllers/mobile_app/sensors_controller.rb
@@ -2,7 +2,16 @@ module MobileApp
   class SensorsController < ApplicationController
     def index
       @sensors = Sensor.order(created_at: :asc)
-      @latest_sensor_temperatures = Measurement.last_per_sensor(1).pluck(:sensor_id, :temperature).to_h
+      @latest_sensor_measurements = Measurement.last_per_sensor(1)
+                                               .pluck(:sensor_id, :temperature, :created_at)
+                                               .map { |fields| [
+                                                 fields[0],
+                                                 {
+                                                   :temperature => fields[1],
+                                                   :created_at => fields[2].to_time.to_i,
+                                                 }
+                                               ]}
+                                               .to_h
     end
 
     def show
@@ -13,6 +22,7 @@ module MobileApp
                       .select('AVG(measurements.temperature) AS average_temperature')
                       .find(params[:id])
       @latest_sensor_temperature = Measurement.where(sensor_id: params[:id]).order(created_at: :desc).first&.temperature
+      @latest_sensor_update = Measurement.where(sensor_id: params[:id]).order(created_at: :desc).first&.created_at
     end
 
     def daily_temperatures

--- a/app/controllers/mobile_app/sensors_controller.rb
+++ b/app/controllers/mobile_app/sensors_controller.rb
@@ -7,8 +7,8 @@ module MobileApp
                                                .map { |fields| [
                                                  fields[0],
                                                  {
-                                                   :temperature => fields[1],
-                                                   :created_at => fields[2].to_time.to_i,
+                                                   temperature: fields[1],
+                                                   created_at: fields[2],
                                                  }
                                                ]}
                                                .to_h

--- a/app/controllers/mobile_app/sensors_controller.rb
+++ b/app/controllers/mobile_app/sensors_controller.rb
@@ -6,10 +6,7 @@ module MobileApp
                                                .pluck(:sensor_id, :temperature, :created_at)
                                                .map { |fields| [
                                                  fields[0],
-                                                 {
-                                                   temperature: fields[1],
-                                                   created_at: fields[2],
-                                                 }
+                                                 {temperature: fields[1], created_at: fields[2]}
                                                ]}
                                                .to_h
     end

--- a/app/views/mobile_app/sensors/index.json.jbuilder
+++ b/app/views/mobile_app/sensors/index.json.jbuilder
@@ -2,5 +2,5 @@ json.array!(@sensors) do |sensor|
   json.extract! sensor, :id, :device_name, :caption, :latitude, :longitude
   json.created_at sensor.created_at.to_i
   json.latest_temperature @latest_sensor_measurements.include?(sensor.id) ? @latest_sensor_measurements[sensor.id][:temperature] : nil
-  json.latest_measurement_at @latest_sensor_measurements.include?(sensor.id) ? @latest_sensor_measurements[sensor.id][:created_at] : nil
+  json.latest_measurement_at @latest_sensor_measurements.include?(sensor.id) ? @latest_sensor_measurements[sensor.id][:created_at].to_i : nil
 end

--- a/app/views/mobile_app/sensors/index.json.jbuilder
+++ b/app/views/mobile_app/sensors/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.array!(@sensors) do |sensor|
   json.extract! sensor, :id, :device_name, :caption, :latitude, :longitude
   json.created_at sensor.created_at.to_i
-  json.latest_temperature @latest_sensor_measurements.include?(sensor.id) ? @latest_sensor_measurements[sensor.id][:temperature] : nil
-  json.latest_measurement_at @latest_sensor_measurements.include?(sensor.id) ? @latest_sensor_measurements[sensor.id][:created_at].to_i : nil
+  json.latest_temperature @latest_sensor_measurements.dig(sensor.id, :temperature)
+  json.latest_measurement_at @latest_sensor_measurements.dig(sensor.id, :created_at)&.to_i
 end

--- a/app/views/mobile_app/sensors/index.json.jbuilder
+++ b/app/views/mobile_app/sensors/index.json.jbuilder
@@ -2,5 +2,5 @@ json.array!(@sensors) do |sensor|
   json.extract! sensor, :id, :device_name, :caption, :latitude, :longitude
   json.created_at sensor.created_at.to_i
   json.latest_temperature @latest_sensor_measurements.include?(sensor.id) ? @latest_sensor_measurements[sensor.id][:temperature] : nil
-  json.latest_sensor_update @latest_sensor_measurements.include?(sensor.id) ? @latest_sensor_measurements[sensor.id][:created_at] : nil
+  json.latest_measurement_at @latest_sensor_measurements.include?(sensor.id) ? @latest_sensor_measurements[sensor.id][:created_at] : nil
 end

--- a/app/views/mobile_app/sensors/index.json.jbuilder
+++ b/app/views/mobile_app/sensors/index.json.jbuilder
@@ -1,5 +1,6 @@
 json.array!(@sensors) do |sensor|
   json.extract! sensor, :id, :device_name, :caption, :latitude, :longitude
   json.created_at sensor.created_at.to_i
-  json.latest_temperature @latest_sensor_temperatures[sensor.id]
+  json.latest_temperature @latest_sensor_measurements.include?(sensor.id) ? @latest_sensor_measurements[sensor.id][:temperature] : nil
+  json.latest_sensor_update @latest_sensor_measurements.include?(sensor.id) ? @latest_sensor_measurements[sensor.id][:created_at] : nil
 end

--- a/app/views/mobile_app/sensors/show.json.jbuilder
+++ b/app/views/mobile_app/sensors/show.json.jbuilder
@@ -1,5 +1,5 @@
 json.extract! @sensor, :id, :device_name, :caption, :latitude, :longitude, :sponsor_id
 json.created_at @sensor.created_at.to_i
-json.latest_temperature @latest_sensor_temperature
-json.latest_measurement_at @latest_measurement_at&.to_time.to_i
+json.latest_temperature @latest_measurement&.temperature
+json.latest_measurement_at @latest_measurement&.created_at&.to_i
 json.extract! @sensor, :minimum_temperature, :maximum_temperature, :average_temperature

--- a/app/views/mobile_app/sensors/show.json.jbuilder
+++ b/app/views/mobile_app/sensors/show.json.jbuilder
@@ -1,4 +1,5 @@
 json.extract! @sensor, :id, :device_name, :caption, :latitude, :longitude, :sponsor_id
 json.created_at @sensor.created_at.to_i
 json.latest_temperature @latest_sensor_temperature
+json.latest_sensor_update @latest_sensor_update&.to_time.to_i
 json.extract! @sensor, :minimum_temperature, :maximum_temperature, :average_temperature

--- a/app/views/mobile_app/sensors/show.json.jbuilder
+++ b/app/views/mobile_app/sensors/show.json.jbuilder
@@ -1,5 +1,5 @@
 json.extract! @sensor, :id, :device_name, :caption, :latitude, :longitude, :sponsor_id
 json.created_at @sensor.created_at.to_i
 json.latest_temperature @latest_sensor_temperature
-json.latest_sensor_update @latest_sensor_update&.to_time.to_i
+json.latest_measurement_at @latest_measurement_at&.to_time.to_i
 json.extract! @sensor, :minimum_temperature, :maximum_temperature, :average_temperature

--- a/test/controllers/mobile_app/sensors_controller_test.rb
+++ b/test/controllers/mobile_app/sensors_controller_test.rb
@@ -17,7 +17,7 @@ module MobileApp
 
       assert_response :success
       assert_equal(parsed_response.first['latest_temperature'], 20)
-      assert_equal(parsed_response.first['latest_sensor_update'], DateTime.parse('2020-08-08').to_time.to_i)
+      assert_equal(parsed_response.first['latest_sensor_update'], 1596837600) # 2020-08-08
     end
 
     test 'should show sensor with minimum, maximum and average temperature' do
@@ -28,7 +28,7 @@ module MobileApp
       get mobile_app_sensor_url(@sensor), env: public_auth_header
 
       assert_response :success
-      assert_equal(parsed_response['latest_sensor_update'], DateTime.parse('2020-08-08 08:00:02').to_time.to_i)
+      assert_equal(parsed_response['latest_sensor_update'], 1596866402) # 2020-08-08 08:00:02
       assert_equal(parsed_response['minimum_temperature'], 3)
       assert_equal(parsed_response['maximum_temperature'], 20)
       assert_equal(parsed_response['average_temperature'], 11)

--- a/test/controllers/mobile_app/sensors_controller_test.rb
+++ b/test/controllers/mobile_app/sensors_controller_test.rb
@@ -11,25 +11,25 @@ module MobileApp
     end
 
     test 'should get sensor index with latest measurement' do
-      @sensor.measurements << create(:measurement, temperature: 20, created_at: DateTime.parse('2020-08-08'))
+      @sensor.measurements << create(:measurement, temperature: 20, created_at: DateTime.parse('2020-08-08').utc)
 
       get mobile_app_sensors_url, env: public_auth_header
 
       assert_response :success
       assert_equal(20, parsed_response.first['latest_temperature'])
-      assert_equal(1596837600, parsed_response.first['latest_measurement_at']) # 2020-08-08
+      assert_equal(1596844800, parsed_response.first['latest_measurement_at']) # 2020-08-08
       assert_equal(@sensor.sponsor.id, parsed_response.first['sponsor_id'])
     end
 
     test 'should show sensor with minimum, maximum and average temperature' do
-      @sensor.measurements << create(:measurement, temperature: 3, created_at: DateTime.parse('2020-08-08 08:00:00'))
-      @sensor.measurements << create(:measurement, temperature: 10, created_at: DateTime.parse('2020-08-08 08:00:02')) # Latest
-      @sensor.measurements << create(:measurement, temperature: 20, created_at: DateTime.parse('2020-08-08 08:00:01'))
+      @sensor.measurements << create(:measurement, temperature: 3, created_at: DateTime.parse('2020-08-08 08:00:00').utc)
+      @sensor.measurements << create(:measurement, temperature: 10, created_at: DateTime.parse('2020-08-08 08:00:02').utc) # Latest
+      @sensor.measurements << create(:measurement, temperature: 20, created_at: DateTime.parse('2020-08-08 08:00:01').utc)
 
       get mobile_app_sensor_url(@sensor), env: public_auth_header
 
       assert_response :success
-      assert_equal(parsed_response['latest_measurement_at'], 1596866402) # 2020-08-08 08:00:02
+      assert_equal(parsed_response['latest_measurement_at'], 1596873602) # 2020-08-08 08:00:02
       assert_equal(parsed_response['minimum_temperature'], 3)
       assert_equal(parsed_response['maximum_temperature'], 20)
       assert_equal(parsed_response['average_temperature'], 11)
@@ -46,10 +46,10 @@ module MobileApp
     end
 
     test 'should show daily aggregated temperatures' do
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-09'), temperature: 5)
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-09'), temperature: 10)
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-10'), temperature: 20)
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-10'), temperature: 30)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-09').utc, temperature: 5)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-09').utc, temperature: 10)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-10').utc, temperature: 20)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-10').utc, temperature: 30)
 
       get daily_temperatures_mobile_app_sensor_url(@sensor), env: public_auth_header
 
@@ -68,11 +68,11 @@ module MobileApp
     end
 
     test 'should show hourly aggregated temperatures' do
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-09 00:01'), temperature: 5)
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-09 00:05'), temperature: 10)
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-09 03:03'), temperature: 20)
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-09 03:59'), temperature: 28)
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-10 00:59'), temperature: 30)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-09 00:01').utc, temperature: 5)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-09 00:05').utc, temperature: 10)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-09 03:03').utc, temperature: 20)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-09 03:59').utc, temperature: 28)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-10 00:59').utc, temperature: 30)
 
       get hourly_temperatures_mobile_app_sensor_url(@sensor), env: public_auth_header
 
@@ -105,11 +105,11 @@ module MobileApp
     end
 
     test 'should filter aggregated temperatures by date' do
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-09'), temperature: 5)
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-09'), temperature: 10)
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-10'), temperature: 20)
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-10'), temperature: 30)
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-11'), temperature: 30)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-09').utc, temperature: 5)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-09').utc, temperature: 10)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-10').utc, temperature: 20)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-10').utc, temperature: 30)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-11').utc, temperature: 30)
 
       open_start_filter = { to: '2020-09-10' }
       get daily_temperatures_mobile_app_sensor_url(@sensor, open_start_filter), env: public_auth_header
@@ -130,9 +130,9 @@ module MobileApp
     end
 
     test 'should filter aggregated temperatures by limit' do
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-01'), temperature: 5)
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-02'), temperature: 10)
-      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-03'), temperature: 20)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-01').utc, temperature: 5)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-02').utc, temperature: 10)
+      @sensor.measurements << create(:measurement, created_at: DateTime.parse('2020-09-03').utc, temperature: 20)
 
       limit_filter = { limit: '2' }
       get daily_temperatures_mobile_app_sensor_url(@sensor, limit_filter), env: public_auth_header

--- a/test/controllers/mobile_app/sensors_controller_test.rb
+++ b/test/controllers/mobile_app/sensors_controller_test.rb
@@ -11,22 +11,24 @@ module MobileApp
     end
 
     test 'should get index with latest measurement' do
-      @sensor.measurements << create(:measurement, temperature: 20)
+      @sensor.measurements << create(:measurement, temperature: 20, created_at: DateTime.parse('2020-08-08'))
 
       get mobile_app_sensors_url, env: public_auth_header
 
       assert_response :success
       assert_equal(parsed_response.first['latest_temperature'], 20)
+      assert_equal(parsed_response.first['latest_sensor_update'], DateTime.parse('2020-08-08').to_time.to_i)
     end
 
     test 'should show sensor with minimum, maximum and average temperature' do
-      @sensor.measurements << create(:measurement, temperature: 3)
-      @sensor.measurements << create(:measurement, temperature: 10)
-      @sensor.measurements << create(:measurement, temperature: 20)
+      @sensor.measurements << create(:measurement, temperature: 3, created_at: DateTime.parse('2020-08-08 08:00:00'))
+      @sensor.measurements << create(:measurement, temperature: 10, created_at: DateTime.parse('2020-08-08 08:00:02')) # Latest
+      @sensor.measurements << create(:measurement, temperature: 20, created_at: DateTime.parse('2020-08-08 08:00:01'))
 
       get mobile_app_sensor_url(@sensor), env: public_auth_header
 
       assert_response :success
+      assert_equal(parsed_response['latest_sensor_update'], DateTime.parse('2020-08-08 08:00:02').to_time.to_i)
       assert_equal(parsed_response['minimum_temperature'], 3)
       assert_equal(parsed_response['maximum_temperature'], 20)
       assert_equal(parsed_response['average_temperature'], 11)

--- a/test/controllers/mobile_app/sensors_controller_test.rb
+++ b/test/controllers/mobile_app/sensors_controller_test.rb
@@ -17,7 +17,7 @@ module MobileApp
 
       assert_response :success
       assert_equal(parsed_response.first['latest_temperature'], 20)
-      assert_equal(parsed_response.first['latest_sensor_update'], 1596837600) # 2020-08-08
+      assert_equal(parsed_response.first['latest_measurement_at'], 1596837600) # 2020-08-08
     end
 
     test 'should show sensor with minimum, maximum and average temperature' do
@@ -28,7 +28,7 @@ module MobileApp
       get mobile_app_sensor_url(@sensor), env: public_auth_header
 
       assert_response :success
-      assert_equal(parsed_response['latest_sensor_update'], 1596866402) # 2020-08-08 08:00:02
+      assert_equal(parsed_response['latest_measurement_at'], 1596866402) # 2020-08-08 08:00:02
       assert_equal(parsed_response['minimum_temperature'], 3)
       assert_equal(parsed_response['maximum_temperature'], 20)
       assert_equal(parsed_response['average_temperature'], 11)


### PR DESCRIPTION
The sensors list/detail responses now include a field called `latest_measurement_at`, containing a UNIX timestamp of the last sensor data update.

```json
$ http GET :3000/api/mobile_app/sensors
[
    {
        "caption": "Hello there",
        "created_at": "2018-06-10T10:33:19.756Z",
        "device_name": "Test Sensor 1",
        "id": 1,
        "latest_measurement_at": 1528626907,
        "latest_temperature": 20.7,
        "latitude": null,
        "longitude": null,
        "url": "http://localhost:3000/api/sensors/1"
    }
]

$ http GET :3000/api/mobile_app/sensors/1
{
    "average_temperature": 20.7,
    "caption": "Hello there",
    "created_at": "2018-06-10T10:33:19.756Z",
    "device_name": "Test Sensor 1",
    "id": 1,
    "latest_measurement_at": 1528626907,
    "latest_temperature": 20.7,
    "latitude": null,
    "longitude": null,
    "maximum_temperature": 20.7,
    "minimum_temperature": 20.7,
    "sponsor_id": null
}
```

Fixes #79.

Datetime format is a UNIX timestamp, see #54.