### PR TITLE
Condense queries

### DIFF
--- a/app/controllers/mobile_app/sensors_controller.rb
+++ b/app/controllers/mobile_app/sensors_controller.rb
@@ -17,26 +17,24 @@ module MobileApp
 
     def daily_temperatures
       @aggregations = Measurement.where(sensor_id: params[:id])
-                                 .group('DATE(created_at)')
-                                 .order('DATE(created_at) DESC')
                                  .select('DATE(created_at) AS aggregation_date')
                                  .select('MIN(measurements.temperature) AS minimum_temperature')
                                  .select('MAX(measurements.temperature) AS maximum_temperature')
                                  .select('AVG(measurements.temperature) AS average_temperature')
+                                 .group('aggregation_date')
+                                 .order('aggregation_date DESC')
       @aggregations = filtered_by_params(@aggregations)
     end
 
     def hourly_temperatures
       @aggregations = Measurement.where(sensor_id: params[:id])
-                                 .group('DATE(created_at)')
-                                 .order('DATE(created_at) DESC')
                                  .select('DATE(created_at) AS aggregation_date')
-                                 .group('EXTRACT(HOUR FROM created_at)')
-                                 .order('EXTRACT(HOUR FROM created_at) DESC')
                                  .select('EXTRACT(HOUR FROM created_at)::integer AS aggregation_hour')
                                  .select('MIN(measurements.temperature) AS minimum_temperature')
                                  .select('MAX(measurements.temperature) AS maximum_temperature')
                                  .select('AVG(measurements.temperature) AS average_temperature')
+                                 .group('aggregation_date, aggregation_hour')
+                                 .order('aggregation_date DESC, aggregation_hour DESC')
       @aggregations = filtered_by_params(@aggregations)
     end
 


### PR DESCRIPTION
Fixes #76 

Apparently the Rails deprecation logic is not able to interpret the argument to `order` on line 35 correctly. This can be fixed by reorganizing the query (which is nice anyways).