### PR TITLE
Fix cp invocation in bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -18,7 +18,7 @@ FileUtils.chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
 
   unless File.exist?('.env')
-    cp '.env.sample', '.env'
+    system! 'cp', '.env.sample', '.env'
   end
 
   puts "\n== Preparing database =="


### PR DESCRIPTION
Previously it did throw an `undefined method `cp' for main:Object`
exception.