### PR TITLE
Hotfix: Enable dynamic assets compilation

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,8 +27,8 @@ Rails.application.configure do
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  # TODO we should not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
This fixes the missing assets in the production environment. It isn't optimal, since normally one prebuilds the assets for production.