### PR TITLE
Let rails log to stdout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,3 +35,4 @@ services:
       RAILS_MAX_THREADS: 2
       WEB_CONCURRENCY: 2
       DATABASE_URL: "postgresql://api:CHANGEME_PASSWORD@db/watertemp_api"
+      RAILS_LOG_TO_STDOUT: true


### PR DESCRIPTION
This makes it much easier to debug, since we can just use `docker logs -f` to see the log messages on the server.