### PR TITLE
Let Rails serve the static files

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,8 +27,8 @@ Rails.application.configure do
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
-  # TODO we should not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = true
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = 'http://assets.example.com'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,3 +36,4 @@ services:
       WEB_CONCURRENCY: 2
       DATABASE_URL: "postgresql://api:CHANGEME_PASSWORD@db/watertemp_api"
       RAILS_LOG_TO_STDOUT: "true"
+      RAILS_SERVE_STATIC_FILES: "true"


### PR DESCRIPTION
We don't have any nginx or similar serving the static files, so we let
Rails do it.

This allows us to revert the hotfix from #119.