### PR TITLE
Fix deployment problem

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,4 +35,4 @@ services:
       RAILS_MAX_THREADS: 2
       WEB_CONCURRENCY: 2
       DATABASE_URL: "postgresql://api:CHANGEME_PASSWORD@db/watertemp_api"
-      RAILS_LOG_TO_STDOUT: true
+      RAILS_LOG_TO_STDOUT: "true"


### PR DESCRIPTION
The Ansible docker_compose module only allows strings, numbers or null in the yaml file:

    RUNNING HANDLER [gfroerli-api : launch docker containers] *********
    fatal: [coredump02.nine.ch]: FAILED! => {"changed": false, "msg": "Configuration error - The Compose file '/srv/docker/watertemp-api/docker-compose.yml' is invalid because:\nservices.api.environment.RAILS_LOG_TO_STDOUT contains true, which is an invalid type, it should be a string, number, or a null"}