### PR TITLE
Build rails assets in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,8 @@ ADD . /code/
 RUN chown -R rails:rails /code
 USER rails
 
+RUN bin/rails assets:precompile
+
 # Stop with SIGINT
 STOPSIGNAL int
 


### PR DESCRIPTION
While testing locally I had the assets pre-built for testing so they got added to the Docker container on build. Since we don't do that on the server (and also shouldn't) it failed.

To fix this we build the assets while building the image.