### PR TITLE
Fix building the Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ ADD . /code/
 RUN chown -R rails:rails /code
 USER rails
 
-RUN bin/rails assets:precompile
+# Precompiling assets for production without requiring secret key
+RUN SECRET_KEY_BASE=dummy bin/rails assets:precompile
 
 # Stop with SIGINT
 STOPSIGNAL int


### PR DESCRIPTION
Since we now require `SECRET_KEY_BASE` in an initializer we need to set it to a dummy value to precompile the assets.