### PR TITLE
Add rubocop-performance as plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
 
 Layout/LineLength:


### PR DESCRIPTION
Fixes the following warning:

    rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in .rubocop.yml.