### PR TITLE
Update reading of .ruby-version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby File.read('.ruby-version').strip
+ruby file: '.ruby-version'
 
 gem 'administrate'
 gem 'bootsnap', '>= 1.4.4', require: false


### PR DESCRIPTION
Newer versions of bundler support reading it from .ruby-version in a more declarative way.