### PR TITLE
Allow overriding measurement timestamp

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,9 @@ Style/Documentation:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Style/GuardClause:
+  Enabled: false
+
 AllCops:
   NewCops: enable
   Exclude:

--- a/app/controllers/measurements_controller.rb
+++ b/app/controllers/measurements_controller.rb
@@ -27,11 +27,6 @@ class MeasurementsController < ApplicationController
   # POST /measurements
   # POST /measurements.json
   def create
-    unless valid_created_at?
-      return render plain: 'Invalid created_at timestamp. Must be within the last 60 minutes.',
-                    status: :bad_request
-    end
-
     @measurement = Measurement.new(measurement_params)
 
     if @measurement.save
@@ -66,18 +61,7 @@ class MeasurementsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def measurement_params
-    params.require(:measurement).permit(:temperature, :sensor_id, :created_at, custom_attributes: {})
-  end
-
-  def valid_created_at?
-    return true if params.dig(:measurement, :created_at).blank?
-
-    submitted_time = Time.zone.parse(params[:measurement][:created_at])
-    return false if submitted_time.nil?
-
-    sixty_minutes_ago = 60.minutes.ago
-
-    submitted_time.between?(sixty_minutes_ago, 3.minutes.from_now)
+    params.require(:measurement).permit(:temperature, :sensor_id, :override_created_at, custom_attributes: {})
   end
 
   def filter_by_ids(ids)

--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -1,11 +1,32 @@
 class Measurement < ApplicationRecord
   belongs_to :sensor
 
+  attribute :override_created_at
+
   validates :temperature, numericality: true
+  validate :override_created_at_within_1_hour, if: :override_created_at?
+
+  before_save :apply_override_created_at
 
   # TODO: rename to latest_per_sensor
   def self.last_per_sensor(count)
     subquery = Measurement.select('*, ROW_NUMBER() OVER (PARTITION BY sensor_id ORDER BY created_at DESC) row_number')
     from(Arel.sql("(#{subquery.to_sql}) as measurements")).where(row_number: ..count)
+  end
+
+  private
+
+  def apply_override_created_at
+    return if override_created_at.nil?
+
+    self.created_at = override_created_at
+  end
+
+  def override_created_at_within_1_hour
+    self.override_created_at = Time.zone.parse(override_created_at)
+
+    unless override_created_at&.between?(60.minutes.ago, 3.minutes.from_now)
+      errors.add :override_created_at, 'Must be within the last 60 minutes.'
+    end
   end
 end

--- a/test/controllers/measurements_controller_test.rb
+++ b/test/controllers/measurements_controller_test.rb
@@ -60,7 +60,7 @@ class MeasurementsControllerTest < ActionDispatch::IntegrationTest
     assert_difference('Measurement.count') do
       post measurements_url, params: { measurement: { sensor_id: @measurement.sensor.id,
                                                       temperature: 20.5,
-                                                      created_at: valid_timestamp.iso8601 } },
+                                                      override_created_at: valid_timestamp.iso8601 } },
                              env: private_auth_header
     end
 
@@ -74,12 +74,12 @@ class MeasurementsControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference('Measurement.count') do
       post measurements_url, params: { measurement: { sensor_id: @measurement.sensor.id,
                                                       temperature: 20.5,
-                                                      created_at: too_old_timestamp.iso8601 } },
+                                                      override_created_at: too_old_timestamp.iso8601 } },
                              env: private_auth_header
     end
 
-    assert_response :bad_request
-    assert_equal 'Invalid created_at timestamp. Must be within the last 60 minutes.', response.body
+    assert_response :unprocessable_content
+    assert_includes response.body, 'Must be within the last 60 minutes.'
   end
 
   test 'should reject measurement with created_at too far in the future' do
@@ -87,12 +87,12 @@ class MeasurementsControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference('Measurement.count') do
       post measurements_url, params: { measurement: { sensor_id: @measurement.sensor.id,
                                                       temperature: 20.5,
-                                                      created_at: too_future_timestamp.iso8601 } },
+                                                      override_created_at: too_future_timestamp.iso8601 } },
                              env: private_auth_header
     end
 
-    assert_response :bad_request
-    assert_equal 'Invalid created_at timestamp. Must be within the last 60 minutes.', response.body
+    assert_response :unprocessable_content
+    assert_includes response.body, 'Must be within the last 60 minutes.'
   end
 
   test 'should accept measurement with created_at slightly in the future' do
@@ -100,7 +100,7 @@ class MeasurementsControllerTest < ActionDispatch::IntegrationTest
     assert_difference('Measurement.count') do
       post measurements_url, params: { measurement: { sensor_id: @measurement.sensor.id,
                                                       temperature: 20.5,
-                                                      created_at: slightly_future_timestamp.iso8601 } },
+                                                      override_created_at: slightly_future_timestamp.iso8601 } },
                              env: private_auth_header
     end
 
@@ -113,12 +113,12 @@ class MeasurementsControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference('Measurement.count') do
       post measurements_url, params: { measurement: { sensor_id: @measurement.sensor.id,
                                                       temperature: 20.5,
-                                                      created_at: 'invalid-timestamp' } },
+                                                      override_created_at: 'invalid-timestamp' } },
                              env: private_auth_header
     end
 
-    assert_response :bad_request
-    assert_equal 'Invalid created_at timestamp. Must be within the last 60 minutes.', response.body
+    assert_response :unprocessable_content
+    assert_includes response.body, 'Must be within the last 60 minutes.'
   end
 
   test 'should update measurement' do

--- a/test/controllers/measurements_controller_test.rb
+++ b/test/controllers/measurements_controller_test.rb
@@ -50,13 +50,13 @@ class MeasurementsControllerTest < ActionDispatch::IntegrationTest
       end
 
       new_measurement = Measurement.last
-      assert_in_delta Time.current, new_measurement.created_at, 1.second
+      assert_equal Time.current, new_measurement.created_at
       assert_response :created
     end
   end
 
   test 'should create measurement with valid created_at timestamp' do
-    valid_timestamp = 30.minutes.ago
+    valid_timestamp = 30.minutes.ago.round
     assert_difference('Measurement.count') do
       post measurements_url, params: { measurement: { sensor_id: @measurement.sensor.id,
                                                       temperature: 20.5,
@@ -65,7 +65,7 @@ class MeasurementsControllerTest < ActionDispatch::IntegrationTest
     end
 
     new_measurement = Measurement.last
-    assert_in_delta valid_timestamp, new_measurement.created_at, 1.second
+    assert_equal valid_timestamp, new_measurement.created_at
     assert_response :created
   end
 
@@ -96,7 +96,7 @@ class MeasurementsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should accept measurement with created_at slightly in the future' do
-    slightly_future_timestamp = 2.minutes.from_now
+    slightly_future_timestamp = 2.minutes.from_now.round
     assert_difference('Measurement.count') do
       post measurements_url, params: { measurement: { sensor_id: @measurement.sensor.id,
                                                       temperature: 20.5,
@@ -105,7 +105,7 @@ class MeasurementsControllerTest < ActionDispatch::IntegrationTest
     end
 
     new_measurement = Measurement.last
-    assert_in_delta slightly_future_timestamp, new_measurement.created_at, 1.second
+    assert_equal slightly_future_timestamp, new_measurement.created_at
     assert_response :created
   end
 

--- a/test/controllers/measurements_controller_test.rb
+++ b/test/controllers/measurements_controller_test.rb
@@ -41,6 +41,86 @@ class MeasurementsControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
+  test 'should create measurement without created_at and use current timestamp' do
+    travel_to Time.zone.parse('2023-01-01 12:00:00') do
+      assert_difference('Measurement.count') do
+        post measurements_url, params: { measurement: { sensor_id: @measurement.sensor.id,
+                                                        temperature: 20.5 } },
+                               env: private_auth_header
+      end
+
+      new_measurement = Measurement.last
+      assert_in_delta Time.current, new_measurement.created_at, 1.second
+      assert_response :created
+    end
+  end
+
+  test 'should create measurement with valid created_at timestamp' do
+    valid_timestamp = 30.minutes.ago
+    assert_difference('Measurement.count') do
+      post measurements_url, params: { measurement: { sensor_id: @measurement.sensor.id,
+                                                      temperature: 20.5,
+                                                      created_at: valid_timestamp.iso8601 } },
+                             env: private_auth_header
+    end
+
+    new_measurement = Measurement.last
+    assert_in_delta valid_timestamp, new_measurement.created_at, 1.second
+    assert_response :created
+  end
+
+  test 'should reject measurement with created_at too far in the past' do
+    too_old_timestamp = 61.minutes.ago
+    assert_no_difference('Measurement.count') do
+      post measurements_url, params: { measurement: { sensor_id: @measurement.sensor.id,
+                                                      temperature: 20.5,
+                                                      created_at: too_old_timestamp.iso8601 } },
+                             env: private_auth_header
+    end
+
+    assert_response :bad_request
+    assert_equal 'Invalid created_at timestamp. Must be within the last 60 minutes.', response.body
+  end
+
+  test 'should reject measurement with created_at too far in the future' do
+    too_future_timestamp = 6.minutes.from_now
+    assert_no_difference('Measurement.count') do
+      post measurements_url, params: { measurement: { sensor_id: @measurement.sensor.id,
+                                                      temperature: 20.5,
+                                                      created_at: too_future_timestamp.iso8601 } },
+                             env: private_auth_header
+    end
+
+    assert_response :bad_request
+    assert_equal 'Invalid created_at timestamp. Must be within the last 60 minutes.', response.body
+  end
+
+  test 'should accept measurement with created_at slightly in the future' do
+    slightly_future_timestamp = 2.minutes.from_now
+    assert_difference('Measurement.count') do
+      post measurements_url, params: { measurement: { sensor_id: @measurement.sensor.id,
+                                                      temperature: 20.5,
+                                                      created_at: slightly_future_timestamp.iso8601 } },
+                             env: private_auth_header
+    end
+
+    new_measurement = Measurement.last
+    assert_in_delta slightly_future_timestamp, new_measurement.created_at, 1.second
+    assert_response :created
+  end
+
+  test 'should reject measurement with invalid created_at timestamp' do
+    assert_no_difference('Measurement.count') do
+      post measurements_url, params: { measurement: { sensor_id: @measurement.sensor.id,
+                                                      temperature: 20.5,
+                                                      created_at: 'invalid-timestamp' } },
+                             env: private_auth_header
+    end
+
+    assert_response :bad_request
+    assert_equal 'Invalid created_at timestamp. Must be within the last 60 minutes.', response.body
+  end
+
   test 'should update measurement' do
     patch measurement_url(@measurement), params: { measurement: { custom_attributes: @measurement.custom_attributes,
                                                                   sensor_id: @measurement.sensor.id,


### PR DESCRIPTION
...but only if it's from the last 60 minutes (to prevent invalid data due to bugs).

To avoid issues with non-synchronized clocks, accept values up to 3 minutes into the future.

This is needed in order to relay measuremenst from BAFU to Gfrörli (where measurements may be from the past).

Note: Please take a good look at the code, I'm a Rails n00b and used Claude 🙂