### PR TITLE
Allow to set sensor shortname via API

### DIFF
--- a/app/controllers/sensors_controller.rb
+++ b/app/controllers/sensors_controller.rb
@@ -49,7 +49,7 @@ class SensorsController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def sensor_params
     # rubocop:disable Rails/StrongParametersExpect -- TODO: Switch to using `params.expect`
-    params.require(:sensor).permit(:device_name, :caption, :sponsor_id, :latitude, :longitude)
+    params.require(:sensor).permit(:device_name, :caption, :sponsor_id, :latitude, :longitude, :shortname)
     # rubocop:enable Rails/StrongParametersExpect
   end
 end

--- a/test/controllers/sensors_controller_test.rb
+++ b/test/controllers/sensors_controller_test.rb
@@ -24,10 +24,10 @@ class SensorsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should create sensor' do
-    assert_difference('Sensor.count') do
+    assert_difference('Sensor.count', 1) do
       post sensors_url, params: { sensor: { caption: @sensor.caption, device_name: @sensor.device_name,
                                             latitude: @sensor.latitude, longitude: @sensor.longitude,
-                                            sponsor_id: @sensor.sponsor.id } },
+                                            sponsor_id: @sensor.sponsor.id, shortname: 'ZH-1' } },
                         env: private_auth_header
     end
 
@@ -37,8 +37,9 @@ class SensorsControllerTest < ActionDispatch::IntegrationTest
   test 'should update sensor' do
     patch sensor_url(@sensor), params: { sensor: { caption: @sensor.caption, device_name: @sensor.device_name,
                                                    latitude: @sensor.latitude, longitude: @sensor.longitude,
-                                                   sponsor_id: @sensor.sponsor.id } },
+                                                   sponsor_id: @sensor.sponsor.id, shortname: 'ZH-1' } },
                                env: private_auth_header
+    assert_equal 'ZH-1', @sensor.reload.shortname
     assert_response :ok
   end
 


### PR DESCRIPTION
This got forgotten in https://github.com/gfroerli/api/pull/296/